### PR TITLE
Fix: Track Classification, Mainline and Industrial Segment Color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,7 +403,7 @@ FodyWeavers.xsd
 # Ignore local project files
 Directory.Build.props
 
-# Ignore .mdf files created by EF Core
+# Ignore .md files created by EF Core
 *.md
 
 # Ignore html

--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,9 @@ FodyWeavers.xsd
 
 # Ignore local project files
 Directory.Build.props
+
+# Ignore .mdf files created by EF Core
+*.md
+
+# Ignore html
+*.html

--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,6 @@ FodyWeavers.xsd
 
 # .nfs files are created when an open file is removed but is still being accessed
 .nfs*
+
+# Ignore local project files
+Directory.Build.props

--- a/MapEnhancer/CanvasCuller.cs
+++ b/MapEnhancer/CanvasCuller.cs
@@ -1,4 +1,5 @@
 using Helpers;
+using Helpers.Culling;
 using System;
 using UI.Map;
 using UnityEngine;
@@ -18,7 +19,13 @@ public class CanvasCuller : MonoBehaviour, CullingManager.ICullingEventHandler
 			cullingToken.Dispose();
 		}
 
-		CullingManager cullingManager = CullingManager.ForName("canvas", new[] { float.PositiveInfinity });
+		CullingManager cullingManager = FindObjectOfType<CullingManager>();
+		if (cullingManager == null)
+		{
+			GameObject go = new GameObject("CanvasCullingManager");
+			cullingManager = go.AddComponent<CullingManager>();
+			cullingManager.Configure("canvas", new[] { float.PositiveInfinity });
+		}  
 		_cullingToken = cullingManager.AddSphere(transform, radius, this);
 		_cullingToken.RegisterFixedUpdate(transform);
 		var camera = MapBuilder.Shared.mapCamera;

--- a/MapEnhancer/Main.cs
+++ b/MapEnhancer/Main.cs
@@ -93,30 +93,30 @@ public static class Loader
 
 		public float TrackLineThickness = 1.25f;
 
-		public MsaaQuality MSAA = MsaaQuality._4x;
+	public MsaaQuality MSAA = MsaaQuality._4x;
 
-		public static readonly Color TrackColorMainlineOrig = new Color(0f, 0f, 1f, 1f);
-		public static readonly Color TrackColorBranchOrig = new Color(0f, 0.572f, 0.792f, 1f);
-		public static readonly Color TrackColorIndustrialOrig = new Color(0.749f, 0.749f, 0f, 1f);
-		public static readonly Color TrackColorUnavailableOrig = new Color(1f, 0f, 0f, 1f);
-		public static readonly Color[] TrackClassColorMap = {
-			new Color(0,0,0,0),
-			new Color(0,0,1,0),
-			new Color(0,1,0,0),
-			new Color(1,0,0,0)};
+	public static readonly Color TrackColorMainlineOrig = new Color(0f, 155f / 255f, 0f, 1f); // Green (RGB 0, 155, 0)
+	public static readonly Color TrackColorBranchOrig = new Color(0f, 0.572f, 0.792f, 1f);
+	public static readonly Color TrackColorIndustrialOrig = new Color(0.749f, 0.749f, 0f, 1f);
+	public static readonly Color TrackColorUnavailableOrig = new Color(1f, 0f, 0f, 1f);
+	public static readonly Color[] TrackClassColorMap = {
+		new Color(0,0,0,0),
+		new Color(0,0,1,0),
+		new Color(0,1,0,0),
+		new Color(1,0,0,0)};
 
-		public Color TrackColorMainline = TrackColorMainlineOrig;
-		public Color TrackColorBranch = TrackColorBranchOrig;
-		public Color TrackColorIndustrial = TrackColorIndustrialOrig;
-		public Color TrackColorUnavailable = TrackColorUnavailableOrig;
-		public static readonly Color TrackColorPaxOrig = new Color(0.5f, 0f, 0.5f, 1f); // Purple
-		public Color TrackColorPax = TrackColorPaxOrig;
+	public Color TrackColorMainline = TrackColorMainlineOrig;
+	public Color TrackColorBranch = TrackColorBranchOrig;
+	public Color TrackColorIndustrial = TrackColorIndustrialOrig;
+	public Color TrackColorUnavailable = TrackColorUnavailableOrig;
+	public static readonly Color TrackColorPaxOrig = new Color(0.5f, 0f, 0.5f, 1f); // Purple
+	public Color TrackColorPax = TrackColorPaxOrig;
 
-		// Feature toggles
-		public bool UseVisualOnlyTrackColors = false; // Visual-only track coloring (doesn't change track classes)
-		public bool EnablePassengerStopTracking = false; // Track passenger stop segments (requires reload)
+	// Feature toggles
+	public bool UseVisualOnlyTrackColors = true; // Visual-only track coloring (doesn't change track classes)
+	public bool EnablePassengerStopTracking = false; // Track passenger stop segments (requires reload)
 
-		public override void Save(UnityModManager.ModEntry modEntry)
+	public override void Save(UnityModManager.ModEntry modEntry)
 		{
 			Save(this, modEntry);
 		}

--- a/MapEnhancer/Main.cs
+++ b/MapEnhancer/Main.cs
@@ -115,6 +115,7 @@ public static class Loader
 	// Feature toggles
 	public bool UseVisualOnlyTrackColors = true; // Visual-only track coloring (doesn't change track classes)
 	public bool EnablePassengerStopTracking = false; // Track passenger stop segments (requires reload)
+	public bool EnableIndustryAreaColors = true; // Color industrial tracks by their area colors (requires reload)
 
 	public override void Save(UnityModManager.ModEntry modEntry)
 		{
@@ -297,7 +298,26 @@ public static class Loader
 			{
 				GUILayout.Label("  ℹ️ Passenger stops will be highlighted in custom color.", GUILayout.ExpandWidth(true));
 				GUILayout.Label("Passenger Stop Track Color");
-				if (DrawColor(ref Settings.TrackColorPax)) changed = true;
+				if (UnityModManager.UI.DrawColor(ref Settings.TrackColorPax)) changed = true;
+			}
+
+			GUILayout.Space(UnityModManager.UI.Scale(5));
+			using (new GUILayout.HorizontalScope())
+			{
+				var industryColors = GUILayout.Toggle(Settings.EnableIndustryAreaColors, "Enable Industry Area Colors (requires map reload)");
+				if (Settings.EnableIndustryAreaColors != industryColors)
+				{
+					Settings.EnableIndustryAreaColors = industryColors;
+					changed = true;
+				}
+			}
+			if (Settings.EnableIndustryAreaColors)
+			{
+				GUILayout.Label("  ℹ️ Industrial tracks will be colored by their area's color.", GUILayout.ExpandWidth(true));
+			}
+			else
+			{
+				GUILayout.Label("  ℹ️ Industrial tracks will use the default industrial color.", GUILayout.ExpandWidth(true));
 			}
 		}
 

--- a/MapEnhancer/Main.cs
+++ b/MapEnhancer/Main.cs
@@ -109,6 +109,12 @@ public static class Loader
 		public Color TrackColorBranch = TrackColorBranchOrig;
 		public Color TrackColorIndustrial = TrackColorIndustrialOrig;
 		public Color TrackColorUnavailable = TrackColorUnavailableOrig;
+		public static readonly Color TrackColorPaxOrig = new Color(0.5f, 0f, 0.5f, 1f); // Purple
+		public Color TrackColorPax = TrackColorPaxOrig;
+
+		// Feature toggles
+		public bool UseVisualOnlyTrackColors = false; // Visual-only track coloring (doesn't change track classes)
+		public bool EnablePassengerStopTracking = false; // Track passenger stop segments (requires reload)
 
 		public override void Save(UnityModManager.ModEntry modEntry)
 		{
@@ -258,6 +264,41 @@ public static class Loader
 			if (DrawColor(ref Settings.TrackColorIndustrial)) changed = true;
 			GUILayout.Label("Unavailable Track Color");
 			if (DrawColor(ref Settings.TrackColorUnavailable)) changed = true;
+
+			GUILayout.Space(UnityModManager.UI.Scale(10));
+			GUILayout.Label("--- Optional Features ---", GUILayout.ExpandWidth(true));
+			
+			GUILayout.Space(UnityModManager.UI.Scale(5));
+			using (new GUILayout.HorizontalScope())
+			{
+				var visualOnly = GUILayout.Toggle(Settings.UseVisualOnlyTrackColors, "Use Visual-Only Track Coloring (doesn't modify track classes)");
+				if (Settings.UseVisualOnlyTrackColors != visualOnly)
+				{
+					Settings.UseVisualOnlyTrackColors = visualOnly;
+					changed = true;
+				}
+			}
+			if (Settings.UseVisualOnlyTrackColors)
+			{
+				GUILayout.Label("  ℹ️ Track colors are visual only. Track classes remain unchanged.", GUILayout.ExpandWidth(true));
+			}
+
+			GUILayout.Space(UnityModManager.UI.Scale(5));
+			using (new GUILayout.HorizontalScope())
+			{
+				var paxTracking = GUILayout.Toggle(Settings.EnablePassengerStopTracking, "Enable Passenger Stop Tracking (requires map reload)");
+				if (Settings.EnablePassengerStopTracking != paxTracking)
+				{
+					Settings.EnablePassengerStopTracking = paxTracking;
+					changed = true;
+				}
+			}
+			if (Settings.EnablePassengerStopTracking)
+			{
+				GUILayout.Label("  ℹ️ Passenger stops will be highlighted in custom color.", GUILayout.ExpandWidth(true));
+				GUILayout.Label("Passenger Stop Track Color");
+				if (DrawColor(ref Settings.TrackColorPax)) changed = true;
+			}
 		}
 
 		if (changed) Settings.OnChange();

--- a/MapEnhancer/MapEnhancer.csproj
+++ b/MapEnhancer/MapEnhancer.csproj
@@ -14,10 +14,18 @@
 
 	<!-- Railroader -->
 	<ItemGroup>
-		<Reference Include="Assembly-CSharp" />
-		<Reference Include="Core" />
-		<Reference Include="Definition" />
-		<Reference Include="Map.Runtime" />
+		<Reference Include="Assembly-CSharp">
+			<HintPath>$(RrManagedDir)\Assembly-CSharp.dll</HintPath>
+		</Reference>
+		<Reference Include="Core">
+			<HintPath>$(RrManagedDir)\Core.dll</HintPath>
+		</Reference>
+		<Reference Include="Definition">
+			<HintPath>$(RrManagedDir)\Definition.dll</HintPath>
+		</Reference>
+		<Reference Include="Map.Runtime">
+			<HintPath>$(RrManagedDir)\Map.Runtime.dll</HintPath>
+		</Reference>
 	</ItemGroup>
 
 	<!-- Mod Loader -->
@@ -34,18 +42,42 @@
 
 	<!-- Unity -->
 	<ItemGroup>
-		<Reference Include="UnityEngine" />
-		<Reference Include="UnityEngine.CoreModule" />
-		<Reference Include="UnityEngine.IMGUIModule" />
-		<Reference Include="UnityEngine.InputModule" />
-		<Reference Include="UnityEngine.PhysicsModule" />
-		<Reference Include="UnityEngine.UI" />
-		<Reference Include="UnityEngine.UIModule" />
-		<Reference Include="UnityEngine.ImageConversionModule" />
-		<Reference Include="UnityEngine.InputLegacyModule" />
-		<Reference Include="Unity.InputSystem" />
-		<Reference Include="Unity.RenderPipelines.Universal.Runtime" />
-		<Reference Include="Unity.TextMeshPro" />
+		<Reference Include="UnityEngine">
+			<HintPath>$(RrManagedDir)\UnityEngine.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.CoreModule">
+			<HintPath>$(RrManagedDir)\UnityEngine.CoreModule.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.IMGUIModule">
+			<HintPath>$(RrManagedDir)\UnityEngine.IMGUIModule.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.InputModule">
+			<HintPath>$(RrManagedDir)\UnityEngine.InputModule.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.PhysicsModule">
+			<HintPath>$(RrManagedDir)\UnityEngine.PhysicsModule.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.UI">
+			<HintPath>$(RrManagedDir)\UnityEngine.UI.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.UIModule">
+			<HintPath>$(RrManagedDir)\UnityEngine.UIModule.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.ImageConversionModule">
+			<HintPath>$(RrManagedDir)\UnityEngine.ImageConversionModule.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.InputLegacyModule">
+			<HintPath>$(RrManagedDir)\UnityEngine.InputLegacyModule.dll</HintPath>
+		</Reference>
+		<Reference Include="Unity.InputSystem">
+			<HintPath>$(RrManagedDir)\Unity.InputSystem.dll</HintPath>
+		</Reference>
+		<Reference Include="Unity.RenderPipelines.Universal.Runtime">
+			<HintPath>$(RrManagedDir)\Unity.RenderPipelines.Universal.Runtime.dll</HintPath>
+		</Reference>
+		<Reference Include="Unity.TextMeshPro">
+			<HintPath>$(RrManagedDir)\Unity.TextMeshPro.dll</HintPath>
+		</Reference>
 	</ItemGroup>
 	
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/MapEnhancer/MapResizer.cs
+++ b/MapEnhancer/MapResizer.cs
@@ -146,8 +146,8 @@ namespace MapEnhancer
 		private void CreateDragHandle()
 		{
 			var image = transform.GetComponent<Image>();
-			image.color = new Color(77f/255f, 69f/255f, 55f/255f, 1f);
-			image.sprite = transform.parent.Find("Chrome/Resize Widget")?.GetComponentInChildren<Image>()?.sprite;
+			image.color = new Color(70f/255f, 69f/255f, 55f/255f, 5f/255f);
+			image.sprite = Resources.Load<Sprite>("UI/ResizeWidget");
 
 			var rect = GetComponent<RectTransform>();
 			rect.SetInsetAndSizeFromParentEdge(RectTransform.Edge.Right, 4f, 22f);

--- a/info.json
+++ b/info.json
@@ -2,7 +2,7 @@
 	"Id": "MapEnhancer",
 	"DisplayName": "Map Enhancer",
 	"Author": "Vanguard",
-	"Version": "1.5.3.1",
+	"Version": "1.5.3.5",
 	"AssemblyName": "MapEnhancer.dll",
 	"EntryMethod": "MapEnhancer.UMM.Loader.Load",
 	"ManagerVersion": "0.32.4",

--- a/info.json
+++ b/info.json
@@ -2,10 +2,10 @@
 	"Id": "MapEnhancer",
 	"DisplayName": "Map Enhancer",
 	"Author": "Vanguard",
-	"Version": "1.5.2",
+	"Version": "1.5.2.2025-fix",
 	"AssemblyName": "MapEnhancer.dll",
 	"EntryMethod": "MapEnhancer.UMM.Loader.Load",
-	"ManagerVersion": "0.27.12",
+	"ManagerVersion": "0.32.4",
 	"HomePage": "https://www.nexusmods.com/railroader/mods/18/",
-	"Repository": "https://raw.githubusercontent.com/mricher-git/rr-mapenhancer-mod/master/repository.json"
+	"Repository": "https://raw.githubusercontent.com/Refizar08/rr-mapenhancer-fix/master/repository.json"
 }

--- a/info.json
+++ b/info.json
@@ -2,7 +2,7 @@
 	"Id": "MapEnhancer",
 	"DisplayName": "Map Enhancer",
 	"Author": "Vanguard",
-	"Version": "1.5.2.2025-fix",
+	"Version": "1.5.3.1",
 	"AssemblyName": "MapEnhancer.dll",
 	"EntryMethod": "MapEnhancer.UMM.Loader.Load",
 	"ManagerVersion": "0.32.4",

--- a/info.json
+++ b/info.json
@@ -2,7 +2,7 @@
 	"Id": "MapEnhancer",
 	"DisplayName": "Map Enhancer",
 	"Author": "Vanguard",
-	"Version": "1.5.3.5",
+	"Version": "1.5.3.6",
 	"AssemblyName": "MapEnhancer.dll",
 	"EntryMethod": "MapEnhancer.UMM.Loader.Load",
 	"ManagerVersion": "0.32.4",

--- a/info.json
+++ b/info.json
@@ -2,7 +2,7 @@
 	"Id": "MapEnhancer",
 	"DisplayName": "Map Enhancer",
 	"Author": "Vanguard",
-	"Version": "1.5.3.6",
+	"Version": "1.5.3.7",
 	"AssemblyName": "MapEnhancer.dll",
 	"EntryMethod": "MapEnhancer.UMM.Loader.Load",
 	"ManagerVersion": "0.32.4",

--- a/repository.json
+++ b/repository.json
@@ -2,6 +2,11 @@
 	"Releases": [
 		{
 			"Id": "MapEnhancer",
+			"Version": "1.5.3.7",
+			"DownloadUrl": "https://github.com/Refizar08/rr-mapenhancer-fix/releases/download/v1.5.3.7/MapEnhancer_v1.5.3.7.zip"
+		},
+		{
+			"Id": "MapEnhancer",
 			"Version": "1.5.3.6",
 			"DownloadUrl": "https://github.com/Refizar08/rr-mapenhancer-fix/releases/download/v1.5.3.6/MapEnhancer_v1.5.3.6.zip"
 		},

--- a/repository.json
+++ b/repository.json
@@ -3,7 +3,7 @@
 		{
 			"Id": "MapEnhancer",
 			"Version": "1.5.2.2025-fix",
-			"DownloadUrl": "https://github.com/Refizar08/rr-mapenhancer-fix/releases/download/v1.5.2.2025-fix/Fix_MapEnhancer_v1.5.2.2025-fix.zip"
+			"DownloadUrl": "https://github.com/Refizar08/rr-mapenhancer-fix/releases/download/v1.5.2.2025-fix/MapEnhancer_v1.5.2.2025-fix.zip"
 		},
 		{
 			"Id": "MapEnhancer",

--- a/repository.json
+++ b/repository.json
@@ -2,6 +2,16 @@
 	"Releases": [
 		{
 			"Id": "MapEnhancer",
+			"Version": "1.5.2.2025-fix",
+			"DownloadUrl": "https://github.com/Refizar08/rr-mapenhancer-fix/releases/download/v1.5.2.2025-fix/Fix_MapEnhancer_v1.5.2.2025-fix.zip"
+		},
+		{
+			"Id": "MapEnhancer",
+			"Version": "1.5.2.2025",
+			"DownloadUrl": "https://github.com/lstealth/rr-mapenhancer-mod/releases/download/v1.5.2.2025/MapEnhancer_v1.5.2.2025.zip"
+		},
+		{
+			"Id": "MapEnhancer",
 			"Version": "1.5.2",
 			"DownloadUrl": "https://github.com/mricher-git/rr-mapenhancer-mod/releases/download/v1.5.2/MapEnhancer_v1.5.2.zip"
 		},

--- a/repository.json
+++ b/repository.json
@@ -2,6 +2,11 @@
 	"Releases": [
 		{
 			"Id": "MapEnhancer",
+			"Version": "1.5.3.6",
+			"DownloadUrl": "https://github.com/Refizar08/rr-mapenhancer-fix/releases/download/v1.5.3.6/MapEnhancer_v1.5.3.6.zip"
+		},
+		{
+			"Id": "MapEnhancer",
 			"Version": "1.5.2.2025-fix",
 			"DownloadUrl": "https://github.com/Refizar08/rr-mapenhancer-fix/releases/download/v1.5.2.2025-fix/MapEnhancer_v1.5.2.2025-fix.zip"
 		},


### PR DESCRIPTION
**Problem:** When MapEnhancer classified track segments during TrackSegment.Awake, other mods or late-created CTC/Industry data could lead to missed mainline/industrial classifications. When we deferred classification we inadvertently overwrote industrial classifications.

**Fix:**
- Defers Mainline/Branch classification until map is fully loaded (OnMapDidLoad).
- Performs a bulk reclassification of all existing TrackSegment objects after map load, preserving Industrial segments already set by other systems.
- Explicitly reapplies industrial classification using IndustryComponent spans to make sure industrial tracks are colored properly.

**Verification done:** built successfully and produced packaged ZIP. In-game, mod should now show mainline and industrial colors reliably even with other map/track mods enabled.